### PR TITLE
Handle WhiteSpaces in Names

### DIFF
--- a/src/ts-exporter.ts
+++ b/src/ts-exporter.ts
@@ -16,7 +16,8 @@ interface IStructure {
  *
  * @param name camelCase name
  */
-const toInterfaceName = (name: string) => name ? `I${name.replace(/^./, (str: string) => str.toUpperCase())}` : 'any';
+const toInterfaceName = (name: string) =>
+  name ? `I${name.replace(/^./, (str: string) => str.toUpperCase()).replace(/[ ]+./g, (str: string) => str.trimLeft().toUpperCase())}` : 'any';
 
 /**
  * Convert a name to a Pascal case name
@@ -36,6 +37,7 @@ export const toSnakeName = (name: string) =>
   name
     .split(/(?=[A-Z])/)
     .join('-')
+    .replace(/[- ]+/g, "-")
     .toLowerCase();
 
 /**


### PR DESCRIPTION
Hi, 

we use whitespaces in our names like "Teaser Gallery for Tags", that create wrong interface and file names.

Before:
` teaser -gallery for -tags.ts / ITeaser Gallery for Tags`
After:
` teaser-gallery-for-tags.ts / ITeaserGalleryForTags`