### PR TITLE
feat: make it possible to configure imports as type imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const config = {
     fieldName: (fieldName) => fieldName.replace('_', ''),
     interfaceName: (name) => `X${name}`,
     enumName: (name, interfaceName) => `Enum${interfaceName}${name}`,
-
+    importAsType: (interfaceName) => interfaceName === 'MyInterfaceThatWantsToImportAsTypes' /* or just true */,
 }
 module.exports = config;
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,6 +64,15 @@ export interface IConfigOptions extends ICommandOptions {
     excludeField: (interfaceName: string, fieldName: string) => boolean | undefined;
 
     /**
+     * Use `import type` in import statements in generated files.
+     * ()
+     * example:
+     *      (interfaceName) => true
+     *      (interfaceName) => interfaceName === 'MyInterface'
+     */
+    importAsType: (interfaceName: string) => boolean | undefined;
+
+    /**
      * add your fields on typescript interface.
      * example:
      *      () => [{ name: "created_by", type: "string" }, { name: "updated_by", type: "string" }]

--- a/src/test/config.js
+++ b/src/test/config.js
@@ -25,6 +25,6 @@ const config = {
             }
         ]
     },
-    importAsType: false
+    importAsType: (interfaceName) => interfaceName !== 'Xuser'
 }
 module.exports = config;

--- a/src/test/config.js
+++ b/src/test/config.js
@@ -24,6 +24,7 @@ const config = {
                 type: "string"
             }
         ]
-    }
+    },
+    importAsType: false
 }
 module.exports = config;

--- a/src/ts-exporter.ts
+++ b/src/ts-exporter.ts
@@ -210,7 +210,7 @@ class Converter {
     const toImportDefinition = (name: string) => {
       const found = findModel(this.strapiModels, name);
       const toFolder = (f: IStrapiModelExtended) => (this.config.nested ? `../${f.snakeName}/${f.snakeName}` : `./${f.snakeName}`);
-      return found ? `import { ${found.interfaceName} } from '${toFolder(found)}';` : '';
+      return found ? `import ${(this.config.importAsType ? 'type ': '')}{ ${found.interfaceName} } from '${toFolder(found)}';` : '';
     };
 
     const imports: string[] = [];

--- a/src/ts-exporter.ts
+++ b/src/ts-exporter.ts
@@ -210,7 +210,7 @@ class Converter {
     const toImportDefinition = (name: string) => {
       const found = findModel(this.strapiModels, name);
       const toFolder = (f: IStrapiModelExtended) => (this.config.nested ? `../${f.snakeName}/${f.snakeName}` : `./${f.snakeName}`);
-      return found ? `import ${(this.config.importAsType ? 'type ': '')}{ ${found.interfaceName} } from '${toFolder(found)}';` : '';
+      return found ? `import ${((this.config.importAsType && this.config.importAsType(m.interfaceName)) ? 'type ': '')}{ ${found.interfaceName} } from '${toFolder(found)}';` : '';
     };
 
     const imports: string[] = [];


### PR DESCRIPTION
Thanks for your work so far. Good stuff.

I made this addition because I'm using your tool to generate the types for use in a Svelte app and the svelte tsconfig has `"importsNotUsedAsValues": "error"`, so it would be nice to be able to add this to the config.

Thanks