### PR TITLE
New: Type dynamiczones

### DIFF
--- a/src/importer.ts
+++ b/src/importer.ts
@@ -123,7 +123,13 @@ export const importFiles = (files: string[]) =>
             componentNames.push(strapiModel.info.name)
           } else {
             console.warn(`Already have component '${strapiModel.info.name}' => skip ${components[sameNameIndex]._filename} use ${strapiModel._filename}`)
-            components[sameNameIndex] = strapiModel;
+            components.push({
+              ...strapiModel,
+              info: {
+                ...strapiModel.info,
+                name: `${componentCollectionName}.${componentModelName}`
+              }
+            });
           }
         } else if (strapiModel.info && strapiModel.info.name) {
           const sameNameIndex = modelNames.indexOf(strapiModel.info.name);

--- a/src/models/strapi-model.ts
+++ b/src/models/strapi-model.ts
@@ -1,4 +1,4 @@
-export type StrapiType = 'string' | 'number' | 'boolean' | 'text' | 'date' | 'email' | 'component' | 'enumeration';
+export type StrapiType = 'string' | 'number' | 'boolean' | 'text' | 'date' | 'email' | 'component' | 'enumeration' | 'dynamiczone';
 
 export interface IStrapiModelAttribute {
   unique?: boolean;
@@ -12,6 +12,7 @@ export interface IStrapiModelAttribute {
   plugin?: string;
   enum?: string[];
   component?: string;
+  components?: string[];
   repeatable?: boolean;
 }
 

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -12,10 +12,10 @@ export const exec = async (options: IConfigOptions) => {
     if(options.inputGroup) files.push(... await findFiles(options.inputGroup, /.json/));
 
     // parse files to object
-    const strapiModels = await importFiles(files);
+    const { models, components } = await importFiles(files);
 
     // build and write .ts
-    const count = await convert(strapiModels, options);
+    const count = await convert(models, components, options);
 
     log(`Generated ${count} interfaces.`);
   } catch (e){

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,4 +1,8 @@
 import { Xfile, Xtestobject, Xtestobjectrelation, EnumXtestobjectenum_field } from './test/out';
+import {Xcontentcomplex} from "./test/out/content.complex";
+import {Xcontentsimple} from "./test/out/content.simple";
+import {Xcontentcamelcase} from "./test/out/content.camel-case";
+import {Xcontentanother} from "./test/out/content.another";
 
 // implementation of Xtestobject test required and type fields
 class XtestobjectXmpl implements Xtestobject {
@@ -24,6 +28,8 @@ class XtestobjectXmpl implements Xtestobject {
     json_field: { [key: string]: any; };
     uid_field: any;
     created_by: string;
+    single_dynamiczone?: [(Xcontentcomplex | Xcontentsimple | Xcontentcamelcase | Xcontentanother)];
+    repeatable_dynamiczone: (Xcontentcomplex | Xcontentsimple | Xcontentcamelcase | Xcontentanother)[];
 
     testobjectrelation?: Xtestobjectrelation;
     testobjectrelations: Xtestobjectrelation[];
@@ -46,6 +52,7 @@ class XtestobjectXmpl implements Xtestobject {
         this.created_by = "created_by";
 
         this.testobjectrelations = [];
+        this.repeatable_dynamiczone = [];
 
         // TOFXX => any field
 

--- a/src/test/api/testobject/models/testobject.settings.json
+++ b/src/test/api/testobject/models/testobject.settings.json
@@ -97,6 +97,26 @@
             "type": "uid",
             "required": true
         },
+        "single_dynamiczone": {
+          "type": "dynamiczone",
+          "repeatable": false,
+          "components": [
+            "content.complex",
+            "content.simple",
+            "content.camel-case",
+            "content.another"
+          ]
+        },
+        "repeatable_dynamiczone": {
+          "type": "dynamiczone",
+          "repeatable": true,
+          "components": [
+            "content.complex",
+            "content.simple",
+            "content.camel-case",
+            "content.another"
+          ]
+        },
         "testobjectrelation": {
             "via": "testobjects_one_many",
             "model": "testobjectrelation"

--- a/src/test/components/content/another.json
+++ b/src/test/components/content/another.json
@@ -1,0 +1,13 @@
+{
+  "collectionName": "components_content_anothers",
+  "info": {
+    "name": "Just a Complete Other Name",
+    "icon": "angle-right"
+  },
+  "options": {},
+  "attributes": {
+    "reference": {
+      "model": "testobject"
+    }
+  }
+}

--- a/src/test/components/content/camel-case.json
+++ b/src/test/components/content/camel-case.json
@@ -1,0 +1,13 @@
+{
+  "collectionName": "components_content_with_dashs",
+  "info": {
+    "name": "WithDash",
+    "icon": "angle-right"
+  },
+  "options": {},
+  "attributes": {
+    "reference": {
+      "model": "testobject"
+    }
+  }
+}

--- a/src/test/components/content/complex.json
+++ b/src/test/components/content/complex.json
@@ -1,0 +1,37 @@
+{
+  "collectionName": "components_content_complexs",
+  "info": {
+    "name": "complex",
+    "icon": "angle-right"
+  },
+  "options": {},
+  "attributes": {
+    "variant": {
+      "type": "enumeration",
+      "enum": [
+        "a",
+        "b"
+      ]
+    },
+    "key": {
+      "type": "string",
+      "regex": "\\w"
+    },
+    "single": {
+      "type": "dynamiczone",
+      "repeatable": false,
+      "components": [
+        "content.complex",
+        "content.simple"
+      ]
+    },
+    "repeatable": {
+      "type": "dynamiczone",
+      "repeatable": true,
+      "components": [
+        "content.complex",
+        "content.simple"
+      ]
+    }
+  }
+}

--- a/src/test/components/content/simple.json
+++ b/src/test/components/content/simple.json
@@ -1,0 +1,13 @@
+{
+  "collectionName": "components_content_simples",
+  "info": {
+    "name": "simple",
+    "icon": "angle-right"
+  },
+  "options": {},
+  "attributes": {
+    "text": {
+      "type": "text"
+    }
+  }
+}

--- a/src/test/config.js
+++ b/src/test/config.js
@@ -4,11 +4,12 @@
 const config = {
     input: [
         'src/test/api/',
-        'src/test/strapi/'
+        'src/test/strapi/',
+        'src/test/components/'
     ],
     output: 'src/test/out/',
     enum: true,
-    fieldType: (fieldType) => { if(fieldType == 'datetime') return 'string'},
+    fieldType: (fieldType) => { if(fieldType === 'datetime') return 'string'},
     // fieldName: (fieldName) => fieldName.replace('_', '-'),
     interfaceName(name){
         return `X${name}`

--- a/src/ts-exporter.ts
+++ b/src/ts-exporter.ts
@@ -31,9 +31,9 @@ const util = {
     if (util.overrideToInterfaceName) {
       const result = util.overrideToInterfaceName(name, filename);
 
-      if (result?.includes(".")) {
-        console.warn("Detected invalid toInterfaceName generated name, note component name can contain '.'.")
-        return result.replace(/./gi, '')
+      if (result?.includes(".") || result?.includes("_") || result?.includes("-")) {
+        console.warn("Detected invalid toInterfaceName generated name, note component name can contain '.', interface names may not contain '._-'.")
+        return result.replace(/[._-]/gi, '')
       }
 
       if (result) {

--- a/src/ts-exporter.ts
+++ b/src/ts-exporter.ts
@@ -31,6 +31,11 @@ const util = {
     if (util.overrideToInterfaceName) {
       const result = util.overrideToInterfaceName(name, filename);
 
+      if (result?.includes(".")) {
+        console.warn("Detected invalid toInterfaceName generated name, note component name can contain '.'.")
+        return result.replace(/./gi, '')
+      }
+
       if (result) {
         return result
       }


### PR DESCRIPTION
This allows typed dynamic zones, like

```
{
  "kind": "collectionType",
  "collectionName": "pages",
  "info": {
    "name": "Page",
    "description": ""
  },
  "attributes": {
    "content": {
      "type": "dynamiczone",
      "components": [
        "content.headline",
        "content.service-link-list"
      ]
    },
  }
}
```

will output

```
import { ContentHeadline } from './content.headline';
import { ContentServiceLinkList } from './content.service-link-list';
/**
 * Model definition for Page
 */
export interface Page {
  content?: (ContentHeadline|ContentServiceLinkList)[];
}
```

this based on my other merge request (https://github.com/erikvullings/strapi-to-typescript/pull/21)

