### PR TITLE
Fix dynamiczone support #33

### DIFF
--- a/src/test/api/testobject/models/testobject.settings.json
+++ b/src/test/api/testobject/models/testobject.settings.json
@@ -115,19 +115,8 @@
             "type": "component",
             "required": true
         },
-        "single_dynamiczone": {
+        "dynamiczone": {
           "type": "dynamiczone",
-          "repeatable": false,
-          "components": [
-            "content.complex",
-            "content.simple",
-            "content.camel-case",
-            "content.another"
-          ]
-        },
-        "repeatable_dynamiczone": {
-          "type": "dynamiczone",
-          "repeatable": true,
           "components": [
             "content.complex",
             "content.simple",

--- a/src/test/components/content/complex.json
+++ b/src/test/components/content/complex.json
@@ -18,16 +18,17 @@
       "regex": "\\w"
     },
     "single": {
-      "type": "dynamiczone",
+      "type": "component",
       "repeatable": false,
-      "components": [
-        "content.complex",
-        "content.simple"
-      ]
+      "component": "content.complex"
     },
     "repeatable": {
-      "type": "dynamiczone",
+      "type": "component",
       "repeatable": true,
+      "component": "content.complex"
+    },
+    "dynamic": {
+      "type": "dynamiczone",
       "components": [
         "content.complex",
         "content.simple"

--- a/src/test/test1.assert.ts
+++ b/src/test/test1.assert.ts
@@ -4,18 +4,24 @@ import { EnumIComplexvariant, IComplex } from "./out1/content/complex";
 import { ISimple } from "./out1/content/simple";
 import { IWithDash } from "./out1/content/camel-case";
 import { IJustACompleteOtherName } from "./out1/content/another";
+import { DynamicZone } from './out1/dynamiczone';
 
 
 class IComplexImpl implements IComplex {
     id: string;
     variant?: EnumIComplexvariant;
     key?: string;
-    single?: IComplex | ISimple;
-    repeatable: (IComplex | ISimple)[];
+    single?: IComplex;
+    repeatable: IComplex[];
+    dynamic: (
+      | DynamicZone<'content.complex', IComplex>
+      | DynamicZone<'content.simple', ISimple>
+    )[];
 
     constructor(){
         this.id = "id";
         this.repeatable = [];
+        this.dynamic = [];
     }
 }
 
@@ -46,8 +52,12 @@ class ItestobjectImpl implements ITestobject {
     component_complex: IComplex;
     component_complex_optional?: IComplex;
     component_complex_repeatable:IComplex[];
-    single_dynamiczone?: IComplex | ISimple | IWithDash | IJustACompleteOtherName;
-    repeatable_dynamiczone: (IComplex | ISimple | IWithDash | IJustACompleteOtherName)[];
+    dynamiczone: (
+      | DynamicZone<'content.complex', IComplex>
+      | DynamicZone<'content.simple', ISimple>
+      | DynamicZone<'content.camel-case', IWithDash>
+      | DynamicZone<'content.another', IJustACompleteOtherName>
+    )[];
 
     testobjectrelation?: ITestobjectrelation;
     testobjectrelations: ITestobjectrelation[];
@@ -70,7 +80,7 @@ class ItestobjectImpl implements ITestobject {
         this.created_by = "created_by";
 
         this.testobjectrelations = [];
-        this.repeatable_dynamiczone = [];
+        this.dynamiczone = [];
 
         // TOFII => any field
 

--- a/src/test/test2.assert.ts
+++ b/src/test/test2.assert.ts
@@ -4,17 +4,23 @@ import { IComplex, EnumIComplexvariant } from "./out2/content/complex";
 import { ISimple } from "./out2/content/simple";
 import { IWithDash } from "./out2/content/camel-case";
 import { IJustACompleteOtherName } from "./out2/content/another";
+import { DynamicZone } from './out2/dynamiczone';
 
 class IComplexImpl implements IComplex {
     id: string;
     variant?: EnumIComplexvariant;
     key?: string;
-    single?: IComplex | ISimple;
-    repeatable: (IComplex | ISimple)[];
+    single?: IComplex;
+    repeatable: IComplex[];
+    dynamic: (
+      | DynamicZone<'content.complex', IComplex>
+      | DynamicZone<'content.simple', ISimple>
+    )[];
 
     constructor(){
         this.id = "id";
         this.repeatable = [];
+        this.dynamic = [];
     }
 }
 
@@ -45,8 +51,12 @@ class ItestobjectImpl implements ITestobject {
     component_complex: IComplex;
     component_complex_optional?: IComplex;
     component_complex_repeatable:IComplex[];
-    single_dynamiczone?: IComplex | ISimple | IWithDash | IJustACompleteOtherName;
-    repeatable_dynamiczone: (IComplex | ISimple | IWithDash | IJustACompleteOtherName)[];
+    dynamiczone: (
+      | DynamicZone<'content.complex', IComplex>
+      | DynamicZone<'content.simple', ISimple>
+      | DynamicZone<'content.camel-case', IWithDash>
+      | DynamicZone<'content.another', IJustACompleteOtherName>
+    )[];
 
     testobjectrelation?: ITestobjectrelation;
     testobjectrelations: ITestobjectrelation[];
@@ -69,7 +79,7 @@ class ItestobjectImpl implements ITestobject {
         this.created_by = "created_by";
 
         this.testobjectrelations = [];
-        this.repeatable_dynamiczone = [];
+        this.dynamiczone = [];
 
         // TOFII => any field
 

--- a/src/test/test3.assert.ts
+++ b/src/test/test3.assert.ts
@@ -4,17 +4,23 @@ import { Xcomplex, EnumXcomplexvariant } from "./out3/content/Xcomplex";
 import { Xsimple } from "./out3/content/Xsimple";
 import { XWithDash } from "./out3/content/XWithDash";
 import { XJustaCompleteOtherName } from "./out3/content/XJustaCompleteOtherName";
+import { DynamicZone } from './out3/dynamiczone';
 
 class XcomplexImpl implements Xcomplex {
     id: string;
     variant?: EnumXcomplexvariant;
     key?: string;
-    single?: Xcomplex | Xsimple;
-    repeatable: (Xcomplex | Xsimple)[];
+    single?: Xcomplex;
+    repeatable: Xcomplex[];
+    dynamic: (
+      | DynamicZone<'content.complex', Xcomplex>
+      | DynamicZone<'content.simple', Xsimple>
+    )[];
 
     constructor(){
         this.id = "id";
         this.repeatable = [];
+        this.dynamic = [];
     }
 }
 
@@ -45,8 +51,12 @@ class ItestobjectImpl implements Xtestobject {
     component_complex: Xcomplex;
     component_complex_optional?: Xcomplex;
     component_complex_repeatable:Xcomplex[];
-    single_dynamiczone?: Xcomplex | Xsimple | XWithDash | XJustaCompleteOtherName;
-    repeatable_dynamiczone: (Xcomplex | Xsimple | XWithDash | XJustaCompleteOtherName)[];
+    dynamiczone: (
+      | DynamicZone<'content.complex', Xcomplex>
+      | DynamicZone<'content.simple', Xsimple>
+      | DynamicZone<'content.camel-case', XWithDash>
+      | DynamicZone<'content.another', XJustaCompleteOtherName>
+    )[];
 
     testobjectrelation?: Xtestobjectrelation;
     testobjectrelations: Xtestobjectrelation[];
@@ -69,7 +79,7 @@ class ItestobjectImpl implements Xtestobject {
         this.created_by = "created_by";
 
         this.testobjectrelations = [];
-        this.repeatable_dynamiczone = [];
+        this.dynamiczone = [];
 
         // TOFII => any field
 


### PR DESCRIPTION
Noticed that the generated typing for dynamic zone fields seemed to be wrong. And there's an issue #33.

The problems:
- With dynamic zones the field is always an array, so `?` is not needed
- With dynamic zones there's this extra field `__component` that has the model name as value

First solution:
- Remove `?` and make it an array
- Wrap each component type within a `DynamicZone` type that attaches the `__component` field.

Resulting diff for my project:
```diff
diff --git a/strapi/content-types/product.ts b/strapi/content-types/product.ts
index 6e0642d..8be9a8d 100644
--- a/strapi/content-types/product.ts
+++ b/strapi/content-types/product.ts
@@ -1,3 +1,4 @@
+import { DynamicZone } from './dynamiczone';
 import { IImgWithList } from './common/img-with-list';
 import { IPanel } from './common/panel';
 import { IQuote } from './common/quote';
@@ -19,7 +20,13 @@ export interface IProduct {
   slug: string;
   metaTitle?: string;
   metaDescription?: string;
-  components?: (IQuote|ITextImgGrid|IImgWithList|ITabbedPanel|IPanel);
+  components: (
+    | DynamicZone<'common.quote', IQuote>
+    | DynamicZone<'common.text-img-grid', ITextImgGrid>
+    | DynamicZone<'common.img-with-list', IImgWithList>
+    | DynamicZone<'common.tabbed-panel', ITabbedPanel>
+    | DynamicZone<'common.panel', IPanel>
+  )[];
 }
```
`dynamiczone.ts`
```typescript
export type DynamicZone<C extends string, T> = {
  __component: C;
} & T;
```

Alternative solutions:
- Undo the `dynamiczone.ts`, instead create `IComplexZone`, `ISimpleZone` etc
  ```typescript
  export interface IComplexZone exte
  }
  ```
  ```typescript
  dynamiczone: (
    | ({ __component: 'content.complex' } & IComplex);
    | ({ __component: 'content.simple' } & ISimple);
    | ({ __component: 'content.camel-case' } & IWithDash);
    | ({ __component: 'content.another' } & IJustACompleteOtherName);
  )[];
  ```