### PR TITLE
quickfix to support Strapi v4

### DIFF
--- a/src/importer.ts
+++ b/src/importer.ts
@@ -103,6 +103,10 @@ export const importFiles = (files: string[], results: IStrapiModel[] = [], merge
         pending--;
 
         let strapiModel = Object.assign(JSON.parse(data), { _filename: f, ...merge })
+
+        if(strapiModel.info && !strapiModel.info.name && strapiModel.info.displayName)
+          strapiModel.info.name = strapiModel.info.displayName;
+        
         if (strapiModel.info && strapiModel.info.name) {
 
           let sameNameIndex = results.map(s => s.info.name).indexOf(strapiModel.info.name);


### PR DESCRIPTION
this simple quickfix supports Strapi V4 by falling back to model.displayName if model.name is undefined